### PR TITLE
Avoid _try_use triggering the "once" warning for Perl 5.12 under "perl -w"

### DIFF
--- a/lib/Locale/Maketext.pm
+++ b/lib/Locale/Maketext.pm
@@ -439,6 +439,7 @@ sub _try_use {   # Basically a wrapper around "require Modulename"
 
     my $module = $_[0];   # ASSUME sane module name!
     { no strict 'refs';
+      no warnings 'once';
         return($tried{$module} = 1)
         if %{$module . '::Lexicon'} or @{$module . '::ISA'};
         # weird case: we never use'd it, but there it is!


### PR DESCRIPTION
Hi Todd,

At Socialtext we have just upgraded to Locale::Maketext 1.17 from the old 1.13 version, and we're seeing "once" warnings from Test::Program:

```
not ok 1 - /home/testrunner/stci/socialtext/nlw/bin/ceq-cleanup compiles
#   Failed test '/home/testrunner/stci/socialtext/nlw/bin/ceq-cleanup compiles'
#   at t/coding-standard/programs-compile.t line 47.
# Warnings: Name "Socialtext::l10n::I18N::en_us::Lexicon" used only once: possible typo at /opt/perl/5.12.2/lib/Locale/Maketext.pm line 443.
```

It might be related to this change:

```
* Release 1.14 (included in perl 5.11.2; not released separately)
In Locale::Maketext, avoid using defined @array and defined %hash.
```

The attached commit fixed the "once" warning by turning it off within the _try_use block.

There's no tests yet (I know...), but hopefully this description makes sufficient sense. :-)

Cheers,
Audrey
